### PR TITLE
Fix: ng version duplicate render & enable prodMode

### DIFF
--- a/packages/viser-ng/src/Chart.ts
+++ b/packages/viser-ng/src/Chart.ts
@@ -318,7 +318,6 @@ export class Chart implements OnInit, AfterViewInit, OnChanges {
           );
         }
       }
-      this.combineContentConfig(name, props, config);
     }
   }
 

--- a/packages/viser-ng/src/module.ts
+++ b/packages/viser-ng/src/module.ts
@@ -1,4 +1,4 @@
-import { NgModule } from '@angular/core';
+import { NgModule, enableProdMode } from '@angular/core';
 import { Chart } from './Chart';
 import { LiteChart } from './LiteChart';
 import { Axis, Coord, Facet, Guide, Legend, Tooltip, View, FacetView, Series, Pie, Sector, Line, SmoothLine, DashLine, Area, StackArea, SmoothArea,
@@ -81,7 +81,7 @@ import * as viser from 'viser';
 })
 export class ViserModule {
 }
-
+enableProdMode();
 export const registerAnimation = viser.registerAnimation;
 export const registerShape = viser.registerShape;
 export const Global = viser.Global;


### PR DESCRIPTION
Fix: ng version duplicate render bug
Feature: enable prodMode, remove [object object] diplayd in container tag