### PR TITLE
fix: avoid the problem that axis show false will block all other axis…

### DIFF
--- a/packages/viser/src/components/setAxisConfig.ts
+++ b/packages/viser/src/components/setAxisConfig.ts
@@ -73,10 +73,12 @@ export const process = (chart: any, config: any) => {
     }
 
     if (res.dataKey) {
-      if (res.show === false) { return chart.axis(res.dataKey, false); }
-
-      const options = _.omit(res, ['show', 'dataKey']);
-      chart.axis(res.dataKey, options);
+      if (res.show === false) {
+        chart.axis(res.dataKey, false);
+      } else {
+        const options = _.omit(res, ['show', 'dataKey']);
+        chart.axis(res.dataKey, options);
+      }
     } else {
       chart.axis(res);
     }


### PR DESCRIPTION
fix: avoid the problem that axis show false will block all other axis after it due to wrong use of keyword return

```
axis1 show=false
axis2 .....
// cause axis2 not display

axis2 .....
axis1 show=false
// no problems
```
