### PR TITLE
fix: v-point的shape设置后不起作用

### DIFF
--- a/packages/viser/src/components/setQuickType.ts
+++ b/packages/viser/src/components/setQuickType.ts
@@ -214,8 +214,8 @@ export const process = (series: any, coord: any) => {
 
     if (currType) {
       series[i] = {
-        ...series[i],
         ...currType.series,
+        ...series[i],
       };
 
       if (coord && coord.type && _.get(currType, 'coord.type') &&


### PR DESCRIPTION
v-point的shape被设置为其他类型之后不起作用，shape属性依旧是circle，注入的配置被默认的配置覆盖