### PR TITLE
fix: unique component id use reverse to avoid component keeping in old

### DIFF
--- a/packages/viser-ng/src/Chart.ts
+++ b/packages/viser-ng/src/Chart.ts
@@ -57,13 +57,16 @@ function omit(obj: any, attr: string) {
 function uniqComponentIdArray(configs: Array<any>) {
   const componentIds: any = {};
   const newConfigs = [];
-  for (let i = 0; i <= (configs.length - 1); i++) {
+  for (let i = (configs.length - 1); i >= 0; i--) {
     const config = configs[i];
     if (!componentIds[config.componentId]) {
       newConfigs.push(config);
       componentIds[config.componentId] = true;
     }
   }
+  newConfigs.sort((ca: any, cb: any) => {
+    return parseInt(ca.componentId, 10) - parseInt(ca.componentId, 10)
+  });
   return newConfigs;
 }
 

--- a/packages/viser-ng/src/Chart.ts
+++ b/packages/viser-ng/src/Chart.ts
@@ -65,7 +65,7 @@ function uniqComponentIdArray(configs: Array<any>) {
     }
   }
   newConfigs.sort((ca: any, cb: any) => {
-    return parseInt(ca.componentId, 10) - parseInt(ca.componentId, 10)
+    return parseInt(ca.componentId, 10) - parseInt(cb.componentId, 10)
   });
   return newConfigs;
 }


### PR DESCRIPTION
fix: unique component id use reverse to avoid component keeping in old version