### PR TITLE
Fix viser-react type error in react 15

### DIFF
--- a/packages/viser-react/src/components/Facet.tsx
+++ b/packages/viser-react/src/components/Facet.tsx
@@ -3,7 +3,7 @@ import * as ReactDOM from "react-dom";
 import * as PropTypes from 'prop-types';
 import { IFacet } from 'viser';
 
-const isReact16 = ReactDOM.createPortal !== undefined;
+const isReact16 = (ReactDOM as any).createPortal !== undefined;
 
 export default class Facet extends React.Component<IFacet, any> {
   static contextTypes = {
@@ -32,7 +32,7 @@ export default class Facet extends React.Component<IFacet, any> {
     }
 
     if (isReact16) {
-      return this.props.children;
+      return this.props.children as React.ReactElement<any>;
     } else {
       return React.Children.only(this.props.children);
     }

--- a/packages/viser-react/src/components/FacetView.tsx
+++ b/packages/viser-react/src/components/FacetView.tsx
@@ -3,7 +3,7 @@ import * as ReactDOM from 'react-dom';
 import * as PropTypes from 'prop-types';
 import { IView } from 'viser';
 
-const isReact16 = ReactDOM.createPortal !== undefined;
+const isReact16 = (ReactDOM as any).createPortal !== undefined;
 
 function generateRandomNum() {
   return (Math.floor(new Date().getTime() + Math.random() * 10000)).toString();
@@ -52,7 +52,7 @@ export default class FacetView extends React.Component<IView, any> {
 
   render() {
     if (isReact16) {
-      return this.props.children;
+      return this.props.children as React.ReactElement<any>;
     } else {
       return React.Children.only(this.props.children);
     }

--- a/packages/viser-react/src/components/View.tsx
+++ b/packages/viser-react/src/components/View.tsx
@@ -3,7 +3,7 @@ import * as ReactDOM from 'react-dom';
 import * as PropTypes from 'prop-types';
 import { IView } from 'viser';
 
-const isReact16 = ReactDOM.createPortal !== undefined;
+const isReact16 = (ReactDOM as any).createPortal !== undefined;
 
 function generateRandomNum() {
   return (Math.floor(new Date().getTime() + Math.random() * 10000)).toString();
@@ -48,7 +48,7 @@ export default class View extends React.Component<IView, any> {
 
   render() {
     if (isReact16) {
-      return this.props.children;
+      return this.props.children as React.ReactElement<any>;
     } else {
       return React.Children.only(this.props.children);
     }


### PR DESCRIPTION
修复 react 15 下面, ts 报错.

package.json 配置:
```json
"@types/react": "~15.0.38",
"@types/react-dom": "15.5.2",
```
报错如下: 
```javascript
[at-loader] Checking finished with 6 errors
[at-loader] ./node_modules/viser-react/src/components/Facet.tsx:6:28
    TS2339: Property 'createPortal' does not exist on type 'typeof "/node_modules/@types/react-dom/index"'.

[at-loader] ./node_modules/viser-react/src/components/Facet.tsx:8:22
    TS2415: Class 'Facet' incorrectly extends base class 'Component<IFacet, any>'.
  Types of property 'render' are incompatible.
    Type '() => {}' is not assignable to type '() => false | Element'.
      Type '{}' is not assignable to type 'false | Element'.
        Type '{}' is not assignable to type 'Element'.

[at-loader] ./node_modules/viser-react/src/components/FacetView.tsx:6:28
    TS2339: Property 'createPortal' does not exist on type 'typeof "/node_modules/@types/react-dom/index"'.

[at-loader] ./node_modules/viser-react/src/components/FacetView.tsx:12:22
    TS2415: Class 'FacetView' incorrectly extends base class 'Component<IView, any>'.
  Types of property 'render' are incompatible.
    Type '() => {}' is not assignable to type '() => false | Element'.
      Type '{}' is not assignable to type 'false | Element'.
        Type '{}' is not assignable to type 'Element'.

[at-loader] ./node_modules/viser-react/src/components/View.tsx:6:28
    TS2339: Property 'createPortal' does not exist on type 'typeof "/node_modules/@types/react-dom/index"'.

[at-loader] ./node_modules/viser-react/src/components/View.tsx:12:22
    TS2415: Class 'View' incorrectly extends base class 'Component<IView, any>'.
  Types of property 'render' are incompatible.
    Type '() => {}' is not assignable to type '() => false | Element'.
      Type '{}' is not assignable to type 'false | Element'.
        Type '{}' is not assignable to type 'Element'.
          Property 'type' is missing in type '{}'.
```