### PR TITLE
Fix viser-ng error in aot mode

### DIFF
--- a/packages/viser-ng/src/Chart.ts
+++ b/packages/viser-ng/src/Chart.ts
@@ -1,7 +1,7 @@
 import { AfterViewInit, Component, Input, OnChanges, SimpleChanges, ViewChild, ViewContainerRef } from '@angular/core';
 import viser, { IScale } from 'viser';
 import { ChartContext } from './chartService';
-import IRChart from './typed/IRChart';
+import { IRChart } from './typed/IRChart';
 
 function firstLowerCase(str: string) {
   return str.replace(/^\S/, (s: any) => {

--- a/packages/viser-ng/src/components/Axis.ts
+++ b/packages/viser-ng/src/components/Axis.ts
@@ -105,4 +105,4 @@ class Axis extends Chart {
   @Input() onGridTouchEnd?: eventFunc;
 }
 
-export default Axis;
+export { Axis };

--- a/packages/viser-ng/src/components/Brush.ts
+++ b/packages/viser-ng/src/components/Brush.ts
@@ -33,4 +33,4 @@ class Brush extends Chart {
   @Input() onDragend?: eventFunc;
 }
 
-export default Brush;
+export { Brush };

--- a/packages/viser-ng/src/components/Coord.ts
+++ b/packages/viser-ng/src/components/Coord.ts
@@ -15,4 +15,4 @@ class Coord extends Chart {
   @Input() endAngle?: number;
 }
 
-export default Coord;
+export { Coord };

--- a/packages/viser-ng/src/components/Facet.ts
+++ b/packages/viser-ng/src/components/Facet.ts
@@ -39,4 +39,4 @@ class Facet extends Chart {
   @Input() eachView?: (views: any, facet: any) => void;
 }
 
-export default Facet;
+export { Facet };

--- a/packages/viser-ng/src/components/Guide.ts
+++ b/packages/viser-ng/src/components/Guide.ts
@@ -56,4 +56,4 @@ class Guide extends Chart {
   @Input() onTouchEnd?: eventFunc;
 }
 
-export default Guide;
+export { Guide };

--- a/packages/viser-ng/src/components/Legend.ts
+++ b/packages/viser-ng/src/components/Legend.ts
@@ -93,4 +93,4 @@ class Legend extends Chart {
   @Input() onTextTouchEnd?: eventFunc;
 }
 
-export default Legend;
+export { Legend };

--- a/packages/viser-ng/src/components/Tooltip.ts
+++ b/packages/viser-ng/src/components/Tooltip.ts
@@ -37,4 +37,4 @@ class Tooltip extends Chart {
   @Input() onChange?: eventFunc;
 }
 
-export default Tooltip;
+export { Tooltip };

--- a/packages/viser-ng/src/components/index.ts
+++ b/packages/viser-ng/src/components/index.ts
@@ -1,10 +1,10 @@
-import Axis from './Axis';
-import Coord from './Coord';
-import Facet from './Facet';
-import Guide from './Guide';
-import Legend from './Legend';
-import Tooltip from './Tooltip';
-import Brush from './Brush';
+import { Axis } from './Axis';
+import { Coord } from './Coord';
+import { Facet } from './Facet';
+import { Guide } from './Guide';
+import { Legend } from './Legend';
+import { Tooltip } from './Tooltip';
+import { Brush } from './Brush';
 import { View, FacetView } from './View';
 import { Series, Pie, Sector, Line, SmoothLine, DashLine, Area, StackArea, SmoothArea, Bar, StackBar, DodgeBar,
   Interval, StackInterval, DodgeInterval, Point, Funnel, Pyramid, Schema, Box, Candle, Polygon, Contour, Heatmap, Edge, Sankey, ErrorBar, JitterPoint } from './Series';

--- a/packages/viser-ng/src/module.ts
+++ b/packages/viser-ng/src/module.ts
@@ -2,7 +2,7 @@ import { NgModule, enableProdMode } from '@angular/core';
 import { Chart } from './Chart';
 import { LiteChart } from './LiteChart';
 import { Axis, Brush, Coord, Facet, Guide, Legend, Tooltip, View, FacetView, Series, Pie, Sector, Line, SmoothLine, DashLine, Area, StackArea, SmoothArea,
- Bar, StackBar, DodgeBar, Point, Funnel, Pyramid, Schema, Box, Candle, Polygon, Contour, Heatmap, Edge, Sankey, ErrorBar, JitterPoint, StackInterval, Interval } from './components/index';
+ Bar, StackBar, DodgeBar, Point, Funnel, Pyramid, Schema, Box, Candle, Polygon, Contour, Heatmap, Edge, Sankey, ErrorBar, JitterPoint, StackInterval, DodgeInterval, Interval } from './components/index';
 import * as viser from 'viser';
 
 @NgModule({
@@ -44,6 +44,7 @@ import * as viser from 'viser';
     ErrorBar,
     JitterPoint,
     StackInterval,
+    DodgeInterval,
     Interval,
   ],
   exports: [
@@ -84,6 +85,7 @@ import * as viser from 'viser';
     ErrorBar,
     JitterPoint,
     StackInterval,
+    DodgeInterval,
     Interval,
   ],
 })

--- a/packages/viser-ng/src/typed/IRChart.ts
+++ b/packages/viser-ng/src/typed/IRChart.ts
@@ -9,4 +9,4 @@ interface ISChartProps {
 
 type IRChart = IChart & ISChartProps;
 
-export default IRChart;
+export { IRChart };


### PR DESCRIPTION
Fix viser-ng error in aot mode
default exports not worked in angular aot mode

reference:
https://github.com/rangle/angular-2-aot-sandbox#default-exports-top