### PR TITLE
import G2 before g2-plugin-slider needed by parcel bundler

### DIFF
--- a/packages/viser/src/plugins/Slider.ts
+++ b/packages/viser/src/plugins/Slider.ts
@@ -1,4 +1,6 @@
 declare const require: any;
+// g2-plugin-slider need G2 loaded first
+import '@antv/g2';
 // tslint:disable-next-line:no-var-requires
 const Slider = require('@antv/g2-plugin-slider');
 


### PR DESCRIPTION
When using viser-vue with Parcel bundler (instead Webpack), Parcel will generate error like this:

```
Uncaught TypeError: Cannot read property 'Chart' of undefined
    at Object.G2 (g2-plugin-slider.js:98)
    at __webpack_require__ (g2-plugin-slider.js:30)
    at Object.G2 (g2-plugin-slider.js:80)
    at __webpack_require__ (g2-plugin-slider.js:30)
    at g2-plugin-slider.js:73
    at g2-plugin-slider.js:76
    at webpackUniversalModuleDefinition (g2-plugin-slider.js:3)
    at Object.parcelRequire.../../node_modules/@antv/g2-plugin-slider/build/g2-plugin-slider.js (g2-plugin-slider.js:10)
    at newRequire (viser-parcel.c8224af7.js:48)
    at localRequire (viser-parcel.c8224af7.js:54)
```
It seems Parcel does not automatically resolve the dependencies like webpack does. So we needed to import G2 manually before g2-plugin-slider, just like the plugin readme suggests.