### PR TITLE
fix: fix Grid types define error

### DIFF
--- a/packages/viser-ng/src/components/Axis.ts
+++ b/packages/viser-ng/src/components/Axis.ts
@@ -51,7 +51,7 @@ class Axis extends Chart {
   @Input() public title?: ITitle;
   @Input() public tick?: IAxisTick;
   @Input() public subTick?: IAxisTick;
-  @Input() public grid?: IAxisGrid;
+  @Input() public grid?: IAxisGrid | null;
   @Input() public zIndex?: number;
   @Input() public label?: boolean | IAxisLabel;
   @Input() public line?: IStyle.ILineStyle;


### PR DESCRIPTION
@arcthur  
If I want to cancel the grid background dashed line, I should set the Axis grid value to null, but I can't do this because gray's typescript type definition doesn't have null.

Docs are so described:

> grid?: IAxisGrid;
> Description: Set the grid pattern of the coordinate axis, and the grid line is perpendicular to the axis of the coordinate. If the attribute value is null, it means that it is not displayed.
